### PR TITLE
Implement /sum-week command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A simple Discord bot built with discord.py.
 
 - Processes `/bot <query>` commands and responds with AI-generated answers using OpenRouter API
 - Summarizes channel conversations with `/sum-day` command to get a summary of the day's messages
+- Summarizes channel conversations with `/sum-week` command to get a summary of the week's messages
 - Automatically generates daily summaries for all active channels at a scheduled time
 - Stores summaries in a dedicated database table and optionally posts them to a reports channel
 - Automatically cleans up old message records after summarization to manage database size
@@ -13,6 +14,7 @@ A simple Discord bot built with discord.py.
 - Rate limiting to prevent abuse (10 seconds between requests, max 6 requests per minute)
 - `/bot` command only responds in the #bot-talk channel
 - `/sum-day` command works in any channel
+- `/sum-week` command works in any channel
 - Stores all messages in a SQLite database for logging and analysis
 
 ## Setup
@@ -76,6 +78,12 @@ To use the message content intent, you need to enable it in the Discord Develope
 ### Channel Summarization
 
 - `/sum-day`: Summarizes all messages in the current channel for the current day
+  - Works in any channel (not restricted to #bot-talk)
+  - The bot retrieves all messages from the channel (including bot responses) except command messages
+  - Sends them to the AI model for summarization
+  - Returns a formatted summary with the main topics and key points discussed
+
+- `/sum-week`: Summarizes all messages in the current channel for the current week
   - Works in any channel (not restricted to #bot-talk)
   - The bot retrieves all messages from the channel (including bot responses) except command messages
   - Sends them to the AI model for summarization

--- a/bot.py
+++ b/bot.py
@@ -15,7 +15,7 @@ from llm_handler import call_llm_api, call_llm_for_summary # Import LLM function
 from message_utils import split_long_message # Import message utility functions
 from summarization_tasks import daily_channel_summarization, set_discord_client, before_daily_summarization # Import summarization tasks
 from config_validator import validate_config # Import config validator
-from command_handler import handle_bot_command, handle_sum_day_command # Import command handlers
+from command_handler import handle_bot_command, handle_sum_day_command, handle_sum_week_command # Import command handlers
 
 # Using message_content intent (requires enabling in the Discord Developer Portal)
 intents = discord.Intents.default()
@@ -114,6 +114,9 @@ async def on_message(message):
         elif message.content.startswith('/sum-day'):
             is_command = True
             command_type = "/sum-day"
+        elif message.content.startswith('/sum-week'):
+            is_command = True
+            command_type = "/sum-week"
 
         # Store in database
         guild_id = str(message.guild.id) if message.guild else None
@@ -149,6 +152,7 @@ async def on_message(message):
     bot_mention_alt = f'<@!{client.user.id}>'
     is_mention_command = message.content.startswith(bot_mention) or message.content.startswith(bot_mention_alt)
     is_sum_day_command = message.content.startswith('/sum-day')
+    is_sum_week_command = message.content.startswith('/sum-week')
 
     # Process mention commands in any channel
     if is_mention_command:
@@ -157,7 +161,7 @@ async def on_message(message):
         return
 
     # If not a command we recognize, ignore
-    if not is_sum_day_command:
+    if not is_sum_day_command and not is_sum_week_command:
         return
 
     # Process commands
@@ -166,6 +170,8 @@ async def on_message(message):
             await handle_bot_command(message, client.user)
         elif is_sum_day_command:
             await handle_sum_day_command(message, client.user)
+        elif is_sum_week_command:
+            await handle_sum_week_command(message, client.user)
     except Exception as e:
         logger.error(f"Error processing command in on_message: {e}", exc_info=True)
         # Optionally notify about the error in the channel if it's a user-facing command error

--- a/test_commands.py
+++ b/test_commands.py
@@ -111,6 +111,25 @@ class TestBotCommands(unittest.TestCase):
             }
         ]
 
+        self.get_channel_messages_for_week_patcher = patch('database.get_channel_messages_for_week')
+        self.mock_get_channel_messages_for_week = self.get_channel_messages_for_week_patcher.start()
+        self.mock_get_channel_messages_for_week.return_value = [
+            {
+                'author_name': 'Test User',
+                'content': 'Test message 1',
+                'created_at': datetime.now(),
+                'is_bot': False,
+                'is_command': False
+            },
+            {
+                'author_name': 'Another User',
+                'content': 'Test message 2',
+                'created_at': datetime.now(),
+                'is_bot': False,
+                'is_command': False
+            }
+        ]
+
     def tearDown(self):
         """Clean up after tests"""
         # Restore original client
@@ -122,6 +141,7 @@ class TestBotCommands(unittest.TestCase):
         self.call_llm_for_summary_patcher.stop()
         self.store_message_patcher.stop()
         self.get_channel_messages_for_day_patcher.stop()
+        self.get_channel_messages_for_week_patcher.stop()
 
     def test_bot_command_in_bot_talk_channel(self):
         """Test /bot command in bot-talk channel"""
@@ -196,6 +216,48 @@ class TestBotCommands(unittest.TestCase):
 
         message = MockMessage(
             content="/sum-day",
+            channel=channel
+        )
+
+        # Process the message
+        import asyncio
+        asyncio.run(bot.on_message(message))
+
+        # Check if the bot responded (should respond in any channel)
+        channel.send.assert_called()
+        self.mock_call_llm_for_summary.assert_called_once()
+
+    def test_sum_week_command_in_bot_talk_channel(self):
+        """Test /sum-week command in bot-talk channel"""
+        # Create mock message in bot-talk channel
+        channel = MagicMock()
+        channel.name = "bot-talk"
+        channel.id = "bot_talk_channel_id"
+        channel.send = AsyncMock()
+
+        message = MockMessage(
+            content="/sum-week",
+            channel=channel
+        )
+
+        # Process the message
+        import asyncio
+        asyncio.run(bot.on_message(message))
+
+        # Check if the bot responded
+        channel.send.assert_called()
+        self.mock_call_llm_for_summary.assert_called_once()
+
+    def test_sum_week_command_in_other_channel(self):
+        """Test /sum-week command in a channel other than bot-talk"""
+        # Create mock message in another channel
+        channel = MagicMock()
+        channel.name = "general"
+        channel.id = "general_channel_id"
+        channel.send = AsyncMock()
+
+        message = MockMessage(
+            content="/sum-week",
             channel=channel
         )
 


### PR DESCRIPTION
Implement a new `/sum-week` command to summarize weekly messages in a Discord channel.

* **command_handler.py**:
  - Add `handle_sum_week_command` function to handle the `/sum-week` command.
  - Retrieve messages for the current week from the database.
  - Generate a summary using the LLM API.
  - Store the generated summary in a thread or the channel.

* **bot.py**:
  - Add a check for the `/sum-week` command in the `on_message` event.
  - Call `handle_sum_week_command` when the `/sum-week` command is detected.

* **database.py**:
  - Add `get_channel_messages_for_week` function to retrieve messages for the current week.

* **README.md**:
  - Update documentation to include the new `/sum-week` command.

* **test_commands.py**:
  - Add tests for the `/sum-week` command in `TestBotCommands`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Undertaker-afk/techfren-discord-bot/pull/1?shareId=f554ffdd-a828-4c28-a13b-ae7590abcf8c).

## Summary by Sourcery

Implement a new `/sum-week` command that gathers messages from the current week, invokes the LLM API to produce a summary, and posts the result in a thread or channel while handling rate limits and error cases.

New Features:
- Add `/sum-week` command to generate AI summaries of the past week's messages in a channel

Enhancements:
- Introduce `get_channel_messages_for_week` for retrieving weekly messages from the database
- Integrate `/sum-week` command into the bot’s message handling and thread posting logic

Documentation:
- Update README with usage details for the `/sum-week` command

Tests:
- Add unit tests for the `/sum-week` command across different channel contexts